### PR TITLE
Fix Dockerfile build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The GUI of the application is accessed through a modern web browser (no installa
 ```
 git clone https://github.com/acaranta/docker-minecraft-client.git
 cd docker-minecraft-client
-git build -t mcclient .
+docker build -t mcclient .
 ```
 
 ## Then Run it


### PR DESCRIPTION
Corrected the build command from 'git build' to 'docker build' in order to properly build the Docker image.